### PR TITLE
Correctly resolve 'parent' to parent not self

### DIFF
--- a/src/main/scala/phantm/phases/SymbolsCollectionPhase.scala
+++ b/src/main/scala/phantm/phases/SymbolsCollectionPhase.scala
@@ -467,7 +467,7 @@ case class CollectSymbols(node: Tree) extends ASTTraversal[SymContext](node, Sym
                                 } else if (id.value == "parent") {
                                     cs.parent match {
                                         case Some(pcs) =>
-                                            id.setSymbol(cs)
+                                            id.setSymbol(pcs)
                                         case None =>
                                             Reporter.error("Class '"+cs.name+"' has no parent", id);
                                     }


### PR DESCRIPTION
There was a small typo causing the parent keyword to be resolved to
the class containing it, instead of that class's parent.
